### PR TITLE
Allow optional list of ignored methods

### DIFF
--- a/http_jwtauth/http.go
+++ b/http_jwtauth/http.go
@@ -17,43 +17,56 @@ func doError(w http.ResponseWriter, req *http.Request, msg string) {
 	w.Write([]byte(msg)) //nolint: errcheck
 }
 
-func Middleware(verifier Verifier) func(http.Handler) http.Handler {
+func Middleware(verifier Verifier, ignoredMethods ...string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			header := req.Header.Get("Authorization")
-			// Parser code taken from grpc-ecosystem/grpc-middleware to match errors
-			splits := strings.SplitN(header, " ", 2)
-			if len(splits) < 2 {
-				doError(w, req, "Bad authorization string")
-				return
-			}
-			if !strings.EqualFold(splits[0], "bearer") {
-				doError(w, req, "Request unauthenticated with bearer")
-				return
-			}
-
-			rawToken := splits[1]
-			if rawToken == "" {
-				doError(w, req, "No Bearer Token")
-				return
-			}
-
 			ctx := req.Context()
 
-			claims, err := verifier.VerifyJWT(rawToken)
-			if err != nil {
-				if ae, ok := err.(jwtauth.AuthError); ok {
-					doError(w, req, string(ae))
+			if !ignoreMethod(req.Method, ignoredMethods) {
+				header := req.Header.Get("Authorization")
+				// Parser code taken from grpc-ecosystem/grpc-middleware to match errors
+				splits := strings.SplitN(header, " ", 2)
+				if len(splits) < 2 {
+					doError(w, req, "Bad authorization string")
 					return
 				}
-				// TODO: Log properly
-				doError(w, req, "Unknown Auth Error")
-				return
+				if !strings.EqualFold(splits[0], "bearer") {
+					doError(w, req, "Request unauthenticated with bearer")
+					return
+				}
 
+				rawToken := splits[1]
+				if rawToken == "" {
+					doError(w, req, "No Bearer Token")
+					return
+				}
+
+				claims, err := verifier.VerifyJWT(rawToken)
+				if err != nil {
+					if ae, ok := err.(jwtauth.AuthError); ok {
+						doError(w, req, string(ae))
+						return
+					}
+					// TODO: Log properly
+					doError(w, req, "Unknown Auth Error")
+					return
+
+				}
+
+				ctx = jwtauth.ToContext(ctx, claims)
 			}
 
-			ctx = jwtauth.ToContext(ctx, claims)
 			next.ServeHTTP(w, req.WithContext(ctx))
 		})
 	}
+}
+
+func ignoreMethod(method string, ignoreList []string) bool {
+	for _, im := range ignoreList {
+		if method == im {
+			return true
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
After adding http_jwtauth to one of our services, we saw preflight OPTIONS requests being denied and throwing CORS errors.

I waffled between hardcoding OPTIONS as an explicit ignore or the ignore list. I opted to go with the ignore list for more generic use, but with variadic args so as to not impact the function signature for prior uses of it.